### PR TITLE
Increase robustness: version check, prevent precompilation with MPI, automatically precompile in the workchain

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,7 @@ aiida-dftk = 'aiida_dftk.cli:cmd_root'
 
 [project.entry-points.'aiida.calculations']
 'dftk' = 'aiida_dftk.calculations:DftkCalculation'
+'dftk.precompile' = 'aiida_dftk.calculations:PrecompileCalculation'
 
 [project.entry-points.'aiida.parsers']
 'dftk' = 'aiida_dftk.parsers:DftkParser'

--- a/src/aiida_dftk/calculations.py
+++ b/src/aiida_dftk/calculations.py
@@ -4,13 +4,16 @@ import io
 import os
 import json
 import typing as ty
-from pathlib import Path
 
 from aiida import orm
 from aiida.common import datastructures, exceptions
-from aiida.engine import CalcJob
+from aiida.engine import CalcJob, ExitCode
 from aiida_pseudo.data.pseudo import UpfData
 from pymatgen.core import units
+
+
+_AIIDA_DFTK_MIN_VERSION = "0.1.9" # inclusive
+_AIIDA_DFTK_MAX_VERSION = "0.2" # exclusive
 
 
 class DftkCalculation(CalcJob):
@@ -62,6 +65,8 @@ class DftkCalculation(CalcJob):
         spec.exit_code(501, 'ERROR_SCF_OUT_OF_WALLTIME',message='The SCF was interuptted due to out of walltime. Non-recovarable error.')
         spec.exit_code(502, 'ERROR_POSTSCF_OUT_OF_WALLTIME',message='The POSTSCF was interuptted due to out of walltime.')
         spec.exit_code(503, 'ERROR_BANDS_CONVERGENCE_NOT_REACHED', message='The BANDS minimization cycle did not converge.')
+        # Significant errors but calculation can be used to restart
+        spec.exit_code(400, 'ERROR_PACKAGE_IMPORT_FAILED', message="Failed to import AiiDA DFTK or write first log message. Typically indicates an environment issue.")
 
         # Outputs
         spec.output('output_parameters', valid_type=orm.Dict, help='output parameters')
@@ -170,12 +175,6 @@ class DftkCalculation(CalcJob):
 
         return data, local_copy_pseudo_list
 
-    def _generate_cmdline_params(self) -> ty.List[str]:
-        # Define the command based on the input settings
-        cmd_params = []
-        cmd_params.extend(['-e', 'using AiidaDFTK; AiidaDFTK.run()', self.metadata.options.input_filename])
-        return cmd_params
-
     def _generate_retrieve_list(self, parameters: orm.Dict) -> list:
         """Generate the list of files to retrieve based on the type of calculation requested in the input parameters.
 
@@ -188,6 +187,7 @@ class DftkCalculation(CalcJob):
             f"{item['$function']}.json" if item['$function'] == 'compute_bands' else f"{item['$function']}.hdf5"
             for item in parameters['postscf']
         ]
+        retrieve_list.append('errors.log')
         retrieve_list.append('timings.json')
         retrieve_list.append(f'{self.SCFRES_SUMMARY_NAME}')
         return retrieve_list
@@ -232,7 +232,12 @@ class DftkCalculation(CalcJob):
                 remote_copy_list.append(checkpointfile_info)
 
         # prepare command line parameters
-        cmdline_params = self._generate_cmdline_params()
+        cmdline_params = [
+            # Precompilation under MPI generally deadlocks. Make sure everything is already precompiled.
+            '--compiled-modules=strict',
+            '-e', f'using AiidaDFTK; AiidaDFTK.run(; min_version=v"{_AIIDA_DFTK_MIN_VERSION}", max_version=v"{_AIIDA_DFTK_MAX_VERSION}")',
+            self.metadata.options.input_filename
+        ]
 
         # prepare retrieve list
         retrieve_list = self._generate_retrieve_list(self.inputs.parameters)
@@ -251,3 +256,52 @@ class DftkCalculation(CalcJob):
         calcinfo.local_copy_list = local_copy_list
 
         return calcinfo
+
+class PrecompileCalculation(CalcJob):
+    """Calcjob implementation to precompile AiidaDFTK."""
+
+    _SUCCESS_PRINT = "Import successful"
+
+    @classmethod
+    def define(cls, spec):
+        """Define the process specification."""
+        super().define(spec)
+
+        options = spec.inputs['metadata']['options']
+        options['resources'].default = {'num_machines': 1, 'num_mpiprocs_per_machine': 1}
+
+    def prepare_for_submission(self, folder):
+        # Set up the `CodeInfo` to pass to `CalcInfo`
+        codeinfo = datastructures.CodeInfo()
+        codeinfo.code_uuid = self.inputs.code.uuid
+        codeinfo.cmdline_params = [
+            '-e', f'using AiidaDFTK; println("{self._SUCCESS_PRINT}")'
+        ]
+        codeinfo.withmpi = False
+
+        # Set up the `CalcInfo` so AiiDA knows what to do with everything
+        calcinfo = datastructures.CalcInfo()
+        calcinfo.codes_info = [codeinfo]
+
+        return calcinfo
+
+    # Easier to override the parse method than to write a parser.
+    def parse(self, *args, **kwargs):
+        exit_code = super().parse(*args, **kwargs)
+        if exit_code.status != 0:
+            return exit_code
+
+        retrieved = self.node.outputs.retrieved
+        filename_stdout = self.node.get_option('scheduler_stdout')
+
+        if filename_stdout is None:
+            self.report('could not determine `stdout` filename because `scheduler_stdout` option was not set.')
+        else:
+            try:
+                scheduler_stdout = retrieved.base.repository.get_object_content(filename_stdout, mode='r')
+                if self._SUCCESS_PRINT in scheduler_stdout:
+                    return ExitCode(0)
+            except FileNotFoundError:
+                self.report(f'could not parse scheduler output: the `{filename_stdout}` file is missing')
+
+        return self.exit_codes.ERROR_UNSPECIFIED

--- a/src/aiida_dftk/calculations.py
+++ b/src/aiida_dftk/calculations.py
@@ -282,7 +282,7 @@ class PrecompileCalculation(CalcJob):
         codeinfo = datastructures.CodeInfo()
         codeinfo.code_uuid = self.inputs.code.uuid
         codeinfo.cmdline_params = [
-            '-e', f'using AiidaDFTK; println("{self._SUCCESS_PRINT}")'
+            '-e', f'using Pkg; Pkg.precompile(; strict=true); using AiidaDFTK; println("{self._SUCCESS_PRINT}")'
         ]
         codeinfo.withmpi = False
 

--- a/src/aiida_dftk/calculations.py
+++ b/src/aiida_dftk/calculations.py
@@ -12,8 +12,7 @@ from aiida_pseudo.data.pseudo import UpfData
 from pymatgen.core import units
 
 
-_AIIDA_DFTK_MIN_VERSION = "0.1.9" # inclusive
-_AIIDA_DFTK_MAX_VERSION = "0.2" # exclusive
+_AIIDA_DFTK_VERSION_SPEC = "0.1.9"
 
 
 class DftkCalculation(CalcJob):
@@ -241,8 +240,10 @@ class DftkCalculation(CalcJob):
         cmdline_params = [
             # Precompilation under MPI generally deadlocks. Make sure everything is already precompiled.
             '--compiled-modules=strict',
-            '-e', f'using AiidaDFTK; AiidaDFTK.run(; min_version=v"{_AIIDA_DFTK_MIN_VERSION}", max_version=v"{_AIIDA_DFTK_MAX_VERSION}")',
-            self.metadata.options.input_filename
+            '-e', 'using AiidaDFTK; AiidaDFTK.run("{}"; allowed_versions="{}")'.format(
+                self.metadata.options.input_filename,
+                _AIIDA_DFTK_VERSION_SPEC,
+            ),
         ]
 
         # prepare retrieve list

--- a/src/aiida_dftk/calculations.py
+++ b/src/aiida_dftk/calculations.py
@@ -12,7 +12,7 @@ from aiida_pseudo.data.pseudo import UpfData
 from pymatgen.core import units
 
 
-_AIIDA_DFTK_VERSION_SPEC = "0.1.9"
+_AIIDA_DFTK_VERSION_SPEC = "0.2.0"
 
 
 class DftkCalculation(CalcJob):
@@ -156,16 +156,23 @@ class DftkCalculation(CalcJob):
 
         local_copy_pseudo_list = []
 
-        data = {'periodic_system': {}, 'model_kwargs': {}, 'basis_kwargs': {}, 'scf': {}, 'postscf': []}
+        data = {
+            'periodic_system': {},
+            'pseudopotentials': {},
+            'model_kwargs': {},
+            'basis_kwargs': {},
+            'scf': {},
+            'postscf': [],
+        }
         data['periodic_system']['bounding_box'] = [[x * units.ang_to_bohr for x in vec] for vec in structure.cell]
         data['periodic_system']['atoms'] = []
         for site in structure.sites:
             data['periodic_system']['atoms'].append({
                 'symbol': site.kind_name,
                 'position': [X * units.ang_to_bohr for X in list(site.position)],
-                'pseudopotential': f'{self._PSEUDO_SUBFOLDER}{pseudos[site.kind_name].filename}'
             })
-            pseudo = pseudos[site.kind_name]
+        for symbol, pseudo in pseudos.items():
+            data['pseudopotentials'][symbol] = f'{self._PSEUDO_SUBFOLDER}{pseudo.filename}'
             local_copy_pseudo_list.append((pseudo.uuid, pseudo.filename, f'{self._PSEUDO_SUBFOLDER}{pseudo.filename}'))
         data['basis_kwargs']['kgrid'], data['basis_kwargs']['kshift'] = kpoints.get_kpoints_mesh()
 

--- a/src/aiida_dftk/calculations.py
+++ b/src/aiida_dftk/calculations.py
@@ -240,7 +240,7 @@ class DftkCalculation(CalcJob):
         cmdline_params = [
             # Precompilation under MPI generally deadlocks. Make sure everything is already precompiled.
             '--compiled-modules=strict',
-            '-e', 'using AiidaDFTK; AiidaDFTK.run("{}"; allowed_versions="{}")'.format(
+            '-e', 'using AiidaDFTK; AiidaDFTK.run(inputfile="{}", allowed_versions="{}")'.format(
                 self.metadata.options.input_filename,
                 _AIIDA_DFTK_VERSION_SPEC,
             ),

--- a/src/aiida_dftk/parsers.py
+++ b/src/aiida_dftk/parsers.py
@@ -40,6 +40,17 @@ class DftkParser(Parser):
             else:
                 return self.exit_codes.ERROR_POSTSCF_OUT_OF_WALLTIME
         
+        # Check error file
+        try:
+            errors_log = self.retrieved.base.repository.get_object_content("errors.log")
+            if "Imports succeeded" not in errors_log:
+                return self.exit_codes.ERROR_PACKAGE_IMPORT_FAILED
+        except FileNotFoundError:
+            return self.exit_codes.ERROR_PACKAGE_IMPORT_FAILED
+
+        if "Finished successfully" not in errors_log:
+            return self.exit_codes.ERROR_UNSPECIFIED
+
         # Check retrieve list to know which files the calculation is expected to have produced.
         try:
             self._parse_optional_result(

--- a/src/aiida_dftk/parsers.py
+++ b/src/aiida_dftk/parsers.py
@@ -42,7 +42,7 @@ class DftkParser(Parser):
         
         # Check error file
         try:
-            errors_log = self.retrieved.base.repository.get_object_content("errors.log")
+            errors_log = self.retrieved.base.repository.get_object_content(DftkCalculation.LOGFILE)
             if "Imports succeeded" not in errors_log:
                 return self.exit_codes.ERROR_PACKAGE_IMPORT_FAILED
         except FileNotFoundError:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,19 +1,30 @@
 import logging
-import os
+from pathlib import Path
 import pytest
+
+import aiida_dftk.calculations
 
 pytest_plugins = 'aiida.manage.tests.pytest_fixtures'
 
 _LOGGER = logging.getLogger(__name__)
-_julia_project_path = os.path.join(__file__, "..", "julia_environment")
+_julia_project_path = Path(__file__).parent /  "julia_environment"
 
 
 def pytest_sessionstart():
     """Instantiates the test Julia environment before any test runs."""
     import subprocess
 
+    with open(_julia_project_path / "Project.toml", "w") as f:
+        f.write(f"""
+[deps]
+AiidaDFTK = "26386dbc-b74b-4d9a-b75a-41d28ada84fc"
+
+[compat]
+AiidaDFTK = "{aiida_dftk.calculations._AIIDA_DFTK_MIN_VERSION}"
+""")
+
     # Pkg.Registry.add() seems necessary for GitHub Actions
-    subprocess.run(['julia', f'--project={_julia_project_path}', '-e', 'using Pkg; Pkg.Registry.add(); Pkg.resolve(); Pkg.precompile();'], check=True)
+    subprocess.run(['julia', f'--project={_julia_project_path}', '-e', 'using Pkg; Pkg.Registry.add(); Pkg.resolve();'], check=True)
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,7 +20,7 @@ def pytest_sessionstart():
 AiidaDFTK = "26386dbc-b74b-4d9a-b75a-41d28ada84fc"
 
 [compat]
-AiidaDFTK = "{aiida_dftk.calculations._AIIDA_DFTK_MIN_VERSION}"
+AiidaDFTK = "{aiida_dftk.calculations._AIIDA_DFTK_VERSION_SPEC}"
 """)
 
     # Pkg.Registry.add() seems necessary for GitHub Actions

--- a/tests/julia_environment/.gitignore
+++ b/tests/julia_environment/.gitignore
@@ -1,2 +1,1 @@
-LocalPreferences.toml
-Manifest.toml
+*

--- a/tests/julia_environment/Project.toml
+++ b/tests/julia_environment/Project.toml
@@ -1,5 +1,0 @@
-[deps]
-AiidaDFTK = "26386dbc-b74b-4d9a-b75a-41d28ada84fc"
-
-[compat]
-AiidaDFTK = "0.1"

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -46,7 +46,7 @@ def test_silicon_workflow(get_dftk_code, generate_structure, generate_kpoints_me
     # we'll need to make sure that tests can run on both GitHub Actions and locally without (too much) special setup.
     builder.dftk.metadata.options.withmpi = False
 
-    result = submit_and_await_success(builder, timeout=300)
+    result = submit_and_await_success(builder, timeout=600)
 
     output_parameters = result.outputs.output_parameters.get_dict()
     assert output_parameters["converged"]


### PR DESCRIPTION
- Update AiidaDFTK to 0.2.
- Add a version check to validate that the AiidaDFTK version matches what we expect. Fixes #10.
- Prevent precompilation deadlocks when running with MPI by passing `--compiled-modules=strict`. Fixes #16.
- Read new `errors.log` output file (see https://github.com/epfl-matmat/AiidaDFTK.jl/pull/23) to detect:
  - Environment issues, when `Imports succeeded` could not be reached.
  - Graceful shutdown, when `Finished successfully` was reached.
- Automatically try to precompile AiidaDFTK in the workchain whenever an environment issue is detected.